### PR TITLE
Changed filters behavior in SQL service

### DIFF
--- a/content/sqlattachmentmanager.go
+++ b/content/sqlattachmentmanager.go
@@ -71,7 +71,7 @@ func (manager SqlAttachmentManager) ListOf(ctx context.Context, opts spellbook.L
 	db := sql.FromContext(ctx)
 	db = db.Offset(opts.Page * opts.Size)
 
-	db = db.Where(sql.FiltersToCondition(opts.Filters))
+	db = db.Where(sql.FiltersToCondition(opts.Filters, nil))
 
 	if opts.Order != "" {
 		dir := " asc"

--- a/content/sqlcontentmanager.go
+++ b/content/sqlcontentmanager.go
@@ -70,7 +70,7 @@ func (manager SqlContentManager) ListOf(ctx context.Context, opts spellbook.List
 	db := sql.FromContext(ctx)
 	db = db.Offset(opts.Page * opts.Size)
 
-	db = db.Where(sql.FiltersToCondition(opts.Filters))
+	db = db.Where(sql.FiltersToCondition(opts.Filters, nil))
 
 	if opts.Order != "" {
 		dir := " asc"

--- a/identity/sqlserviceaccountmanager.go
+++ b/identity/sqlserviceaccountmanager.go
@@ -71,7 +71,7 @@ func (manager SqlServiceAccountManager) ListOf(ctx context.Context, opts spellbo
 	db := sql.FromContext(ctx)
 	db = db.Offset(opts.Page * opts.Size)
 
-	db = db.Where(sql.FiltersToCondition(opts.Filters))
+	db = db.Where(sql.FiltersToCondition(opts.Filters, nil))
 
 	if opts.Order != "" {
 		dir := " asc"

--- a/identity/sqlusermanager.go
+++ b/identity/sqlusermanager.go
@@ -66,7 +66,7 @@ func (manager SqlUserManager) ListOf(ctx context.Context, opts spellbook.ListOpt
 	db := sql.FromContext(ctx)
 	db = db.Offset(opts.Page * opts.Size)
 
-	db = db.Where(sql.FiltersToCondition(opts.Filters))
+	db = db.Where(sql.FiltersToCondition(opts.Filters, nil))
 
 	if opts.Order != "" {
 		dir := " asc"

--- a/sql/service.go
+++ b/sql/service.go
@@ -108,7 +108,7 @@ func FiltersToCondition(fs []spellbook.Filter, conditionsForFilters map[string]f
 		}
 		var filterCondition func(spellbook.Filter) string
 		if conditionsForFilters != nil {
-			if fc, ok := conditionsForFilters[gorm.ToColumnName(f.Value)]; ok {
+			if fc, ok := conditionsForFilters[gorm.ToColumnName(f.Field)]; ok {
 				filterCondition = fc
 			}
 		}

--- a/sql/service.go
+++ b/sql/service.go
@@ -5,7 +5,6 @@ import (
 	"decodica.com/spellbook"
 	"fmt"
 	"github.com/jinzhu/gorm"
-	"strconv"
 	"strings"
 )
 
@@ -88,21 +87,17 @@ func OperatorToSymbol(op spellbook.FilterOperator) string {
 	return "="
 }
 
-func FilterToCondition(f spellbook.Filter) string {
+func FilterToCondition(f spellbook.Filter, filterCondition func(spellbook.Filter) string) string {
+	if filterCondition != nil {
+		return filterCondition(f)
+	}
 	os := OperatorToSymbol(f.Operator)
 	dbField := ToColumnName(f.Field)
-	val := f.Value
-	if val == "null" && f.Operator == spellbook.FilterOperatorExact {
-		return fmt.Sprintf("%q IS NULL", dbField)
-	}
-	if iVal, err := strconv.Atoi(val); err == nil {
-		return fmt.Sprintf("%q %s %d", dbField, os, iVal)
-	}
 	return fmt.Sprintf("%q %s '%s'", dbField, os, f.Value)
 }
 
 
-func FiltersToCondition(fs []spellbook.Filter) string {
+func FiltersToCondition(fs []spellbook.Filter, conditionsForFilters map[string]func(spellbook.Filter) string) string {
 	if fs == nil || len(fs) == 0 {
 		return ""
 	}
@@ -111,7 +106,13 @@ func FiltersToCondition(fs []spellbook.Filter) string {
 		if i > 0 {
 			where.WriteString(" AND ")
 		}
-		where.WriteString(FilterToCondition(f))
+		var filterCondition func(spellbook.Filter) string
+		if conditionsForFilters != nil {
+			if fc, ok := conditionsForFilters[gorm.ToColumnName(f.Value)]; ok {
+				filterCondition = fc
+			}
+		}
+		where.WriteString(FilterToCondition(f, filterCondition))
 	}
 	return where.String()
 }


### PR DESCRIPTION
Changed filters behavior in SQL service due to undesirable consequences in auto-casting filter value types. Now the filter sql handling must be specified by client application, otherwise it will be assumed to be a string.
